### PR TITLE
refactor: implementar interfaces e inverciones de dependencias

### DIFF
--- a/src/infraestructura/adaptadores/gets.js
+++ b/src/infraestructura/adaptadores/gets.js
@@ -1,17 +1,25 @@
-const express = require("express")
-const Escultor = require('./../../modelos/Escultor'); 
+const express = require("express");
+const IEscultorService = require('../../puertos/IEscultorService');
 
-router= express.Router()
+function createGetRouter(escultorService) {
+    const router = express.Router();
 
-router.get("/",(req, res)=>{
-    res.redirect("/public/index.html")
-})
+    router.get("/", (req, res) => {
+        res.redirect("/public/index.html");
+    });
 
-router.get("/api/voting", async (req, res) => {
-    let escultores= await Escultor.find({});
-    res.send(JSON.stringify(escultores))
-})
+    router.get("/api/voting", async (req, res) => {
+        try {
+            let escultores = await escultorService.obtenerEscultores();
+            res.json(escultores);
+        } catch (error) {
+            res.status(500).send('Error al obtener escultores');
+        }
+    });
 
-router.use("/public", express.static("./public"))
+    router.use("/public", express.static("./public"));
 
-module.exports= router
+    return router;
+}
+
+module.exports = createGetRouter;

--- a/src/infraestructura/adaptadores/posts.js
+++ b/src/infraestructura/adaptadores/posts.js
@@ -1,24 +1,21 @@
-const express = require("express")
-const Escultor = require('./../../modelos/Escultor'); 
+const express = require("express");
+const IEscultorService = require('../../puertos/IEscultorService');
 
-router= express.Router()
+function createPostRouter(escultorService) {
+    const router = express.Router();
 
-
-// Rutas para escultores y votación (agrega tus rutas aquí)
-router.post('/api/voting/*', async (req, res) => {
-    const id  = String(req.url).replace("/api/voting/", "");
-    console.log('ID recibido:', id);  // Esto te ayudará a verificar el ID que llega
-    try {
-        const escultor = await Escultor.findById(id);
-        if (!escultor) {
-            return res.status(404).send('Escultor no encontrado');
+    router.post('/api/voting/*', async (req, res) => {
+        const id = String(req.url).replace("/api/voting/", "");
+        console.log('ID recibido:', id);
+        try {
+            await escultorService.votarPorEscultor(id);
+            res.send('Voto registrado');
+        } catch (error) {
+            res.status(500).send('Error al registrar el voto');
         }
-        escultor.votos += 1;
-        await escultor.save();
-        res.send('Voto registrado');
-    } catch (error) {
-        res.status(500).send('Error al registrar el voto');
-    }
-});
+    });
 
-module.exports= router
+    return router;
+}
+
+module.exports = createPostRouter;

--- a/src/puertos/IEscultorRepository.js
+++ b/src/puertos/IEscultorRepository.js
@@ -1,0 +1,7 @@
+class IEscultorRepository {
+    async obtenerPorId(id) {}
+    async actualizarEscultor(escultor) {}
+    async obtenerTodos() {}
+}
+
+module.exports = IEscultorRepository;

--- a/src/puertos/IEscultorService.js
+++ b/src/puertos/IEscultorService.js
@@ -1,0 +1,6 @@
+class IEscultorService {
+    async votarPorEscultor(id) {}
+    async obtenerEscultores() {}
+}
+
+module.exports = IEscultorService;

--- a/src/repositorios/EscultorRepository.js
+++ b/src/repositorios/EscultorRepository.js
@@ -1,12 +1,17 @@
+const IEscultorRepository = require('../puertos/IEscultorRepository');
 const Escultor = require('../modelos/Escultor');
 
-class EscultorRepository {
-    static async obtenerPorId(id) {
+class EscultorRepository extends IEscultorRepository {
+    async obtenerPorId(id) {
         return await Escultor.findById(id);
     }
 
-    static async actualizarEscultor(escultor) {
+    async actualizarEscultor(escultor) {
         return await escultor.save();
+    }
+
+    async obtenerTodos() {
+        return await Escultor.find({});
     }
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,16 +1,24 @@
 const express = require('express');
-require("dotenv").config({path:".dev.env"})
+require("dotenv").config({path:".dev.env"});
 const { default: mongoose } = require('mongoose');
-const getRoutes= require("./infraestructura/adaptadores/gets")
-const postRoutes= require("./infraestructura/adaptadores/posts")
+const createGetRouter = require("./infraestructura/adaptadores/gets");
+const createPostRouter = require("./infraestructura/adaptadores/posts");
+const EscultorRepository = require('./repositorios/EscultorRepository');
+const EscultorService = require('./servicios/EscultorService');
+
 const app = express();
-const PORT = Number(process.env.PORT) | 3000;
-const DBURI= process.env.MONGODBURI
+const PORT = Number(process.env.PORT) || 3000;
+const DBURI = process.env.MONGODBURI;
 
-app.use(postRoutes)
-app.use(getRoutes)
+app.use(express.json());
+app.use(express.static('public')); // agregada en proceso de debuggin incluyendo `listaParaVotar.forEach`
 
-app.use(express.json()); // Para poder recibir JSON en las solicitudes
+// Dependency Injection
+const escultorRepository = new EscultorRepository();
+const escultorService = new EscultorService(escultorRepository);
+
+app.use(createPostRouter(escultorService));
+app.use(createGetRouter(escultorService));
 
 // Conectar a MongoDB
 mongoose.connect(DBURI)
@@ -40,8 +48,7 @@ const insertarEscultores = async () => {
   };
 
 insertarEscultores();*/
-
 // Iniciar el servidor
 app.listen(PORT, () => {
-  console.log(`Servidor HTTP corriendo en http://localhost:${PORT}`);
+    console.log(`Servidor HTTP corriendo en http://localhost:${PORT}`);
 });

--- a/src/servicios/EscultorService.js
+++ b/src/servicios/EscultorService.js
@@ -1,11 +1,21 @@
+const IEscultorService = require('../puertos/IEscultorService');
 const EscultorRepository = require('../repositorios/EscultorRepository');
 
-class EscultorService {
-    static async votarPorEscultor(id) {
-        const escultor = await EscultorRepository.obtenerPorId(id);
+class EscultorService extends IEscultorService {
+    constructor(escultorRepository) {
+        super();
+        this.escultorRepository = escultorRepository;
+    }
+
+    async votarPorEscultor(id) {
+        const escultor = await this.escultorRepository.obtenerPorId(id);
         if (!escultor) throw new Error('Escultor no encontrado');
         escultor.votos += 1;
-        await EscultorRepository.actualizarEscultor(escultor);
+        await this.escultorRepository.actualizarEscultor(escultor);
+    }
+
+    async obtenerEscultores() {
+        return await this.escultorRepository.obtenerTodos();
     }
 }
 


### PR DESCRIPTION
1. Se definen interfaces para/de los puertos (de entrada y salida)
2. Se hizo que las capas de dominio y de aplicación no dependan nada externo
3. Se usó inyección de dependencias para dar implementaciones de los puertos a los servicios
4. Se usan servicios de la aplicación en sus adaptadores en vez de directamente